### PR TITLE
feat: add search filter to catalogue

### DIFF
--- a/src/pages/Catalogue.tsx
+++ b/src/pages/Catalogue.tsx
@@ -18,6 +18,7 @@ interface Product {
 export default function Catalogue() {
   const [products, setProducts] = useState<Product[]>([])
   const [loading, setLoading] = useState(true)
+  const [searchQuery, setSearchQuery] = useState('')
 
   useEffect(() => {
     const fetchProducts = async () => {
@@ -34,14 +35,33 @@ export default function Catalogue() {
     fetchProducts()
   }, [])
 
+  const filteredProducts = products.filter((product) => {
+    const query = searchQuery.toLowerCase()
+    if (!query) return true
+    return (
+      product.top_notes.toLowerCase().includes(query) ||
+      product.heart_notes.toLowerCase().includes(query) ||
+      product.base_notes.toLowerCase().includes(query)
+    )
+  })
+
   return (
     <div className="p-4">
       <h1 className="text-2xl font-bold mb-4">Catalogue Lolly</h1>
+      <input
+        type="text"
+        placeholder="Rechercher un parfum..."
+        value={searchQuery}
+        onChange={(e) => setSearchQuery(e.target.value)}
+        className="mb-4 w-full rounded-md border border-gray-300 px-3 py-2"
+      />
       {loading ? (
         <p>Chargement...</p>
+      ) : filteredProducts.length === 0 ? (
+        <p>Aucun parfum trouvé</p>
       ) : (
         <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4">
-          {products.map((product) => (
+          {filteredProducts.map((product) => (
             <div key={product.id} className="bg-white rounded-2xl shadow-md p-4">
               <img
                 src={product.image_url}
@@ -53,8 +73,10 @@ export default function Catalogue() {
                 Inspiré de {product.inspired_name} – {product.inspired_brand}
               </p>
               <p className="text-sm mt-2">
-                <strong>Notes de tête :</strong> {product.top_notes}<br />
-                <strong>Notes de cœur :</strong> {product.heart_notes}<br />
+                <strong>Notes de tête :</strong> {product.top_notes}
+                <br />
+                <strong>Notes de cœur :</strong> {product.heart_notes}
+                <br />
                 <strong>Notes de fond :</strong> {product.base_notes}
               </p>
               <p className="text-sm mt-2 text-gray-600">{product.description}</p>


### PR DESCRIPTION
## Summary
- add search input to catalogue page
- filter products by notes and show empty state

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: ESLint couldn't find an eslint.config file)*
- `npm run build` *(fails: TS2448 errors in other components)*

------
https://chatgpt.com/codex/tasks/task_e_688d785a96cc832b9b81e78653e822da