### PR TITLE
feat: add catalogue search and variants

### DIFF
--- a/src/pages/Catalogue.tsx
+++ b/src/pages/Catalogue.tsx
@@ -88,23 +88,38 @@ export default function Catalogue() {
   const filteredProducts = products.filter((product) => {
     const query = searchQuery.toLowerCase()
     if (!query) return true
-    return (
-      product.top_notes.toLowerCase().includes(query) ||
-      product.heart_notes.toLowerCase().includes(query) ||
-      product.base_notes.toLowerCase().includes(query)
+
+    const fields = [
+      product.lolly_name,
+      product.inspired_name,
+      product.inspired_brand,
+      product.top_notes,
+      product.heart_notes,
+      product.base_notes,
+    ]
+
+    return fields.some((field) =>
+      (field || '').toLowerCase().includes(query),
     )
   })
 
   return (
     <div className="p-4">
       <h1 className="text-2xl font-bold mb-4">Catalogue Lolly</h1>
-      <input
-        type="text"
-        placeholder="Rechercher un parfum..."
-        value={searchQuery}
-        onChange={(e) => setSearchQuery(e.target.value)}
-        className="mb-4 w-full rounded-md border border-gray-300 px-3 py-2"
-      />
+      <div className="mb-4">
+        <label htmlFor="search" className="sr-only">
+          Rechercher un parfum
+        </label>
+        <input
+          id="search"
+          type="text"
+          placeholder="Rechercher un parfum..."
+          value={searchQuery}
+          onChange={(e) => setSearchQuery(e.target.value)}
+          className="w-full rounded-md border border-gray-300 px-3 py-2"
+          aria-label="Rechercher un parfum"
+        />
+      </div>
       {loading ? (
         <p>Chargement...</p>
       ) : filteredProducts.length === 0 ? (

--- a/src/pages/Catalogue.tsx
+++ b/src/pages/Catalogue.tsx
@@ -1,5 +1,3 @@
-// src/pages/Catalogue.tsx
-
 import { useEffect, useState } from 'react'
 import { supabase } from '../lib/supabase'
 
@@ -28,11 +26,11 @@ export default function Catalogue() {
   const [loading, setLoading] = useState(true)
   const [searchQuery, setSearchQuery] = useState('')
 
-  const formatPrice = (price: number) =>
-    price.toLocaleString('fr-FR', {
-      minimumFractionDigits: 3,
-      maximumFractionDigits: 3,
-    })
+  const priceFormatter = new Intl.NumberFormat('fr-FR', {
+    minimumFractionDigits: 3,
+    maximumFractionDigits: 3,
+  })
+  const formatPrice = (price: number) => priceFormatter.format(price)
 
   useEffect(() => {
     const fetchData = async () => {


### PR DESCRIPTION
## Summary
- add search input to catalogue page
- filter products by notes and show empty state
- load product variants and display volume and price

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: ESLint couldn't find an eslint.config file)*
- `npm run build` *(fails: TS2448 errors in ConseillereDashboard.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_688d785a96cc832b9b81e78653e822da