### PR TITLE
feat: add supabase auth with role-based access

### DIFF
--- a/authentification.md
+++ b/authentification.md
@@ -1,0 +1,57 @@
+# Authentification et gestion des rôles
+
+Ce module met en place l'authentification Supabase (email/mot de passe et Facebook) et la répartition des utilisateurs par rôle : `client`, `advisor`, `admin`.
+
+## Flux général
+```text
+[Utilisateur]
+   | 1. email/password ou Facebook
+   v
+[Supabase Auth] --2. insertion--> [Table users (id, role, facebook_id, messenger_id)]
+   | 3. session retournée
+   v
+[AuthProvider] --4. contexte React--> [UI & ProtectedRoute]
+```
+
+1. L'utilisateur se connecte ou crée un compte via Supabase.
+2. Si l'utilisateur n'existe pas encore dans `users`, son profil est inséré avec le rôle approprié et les identifiants Facebook/Messenger.
+3. `AuthProvider` écoute les changements de session et récupère le profil depuis la base.
+4. `useAuth` expose les informations au frontend et `ProtectedRoute` protège les pages selon le rôle.
+
+## Inscription email
+```ts
+const { error } = await signUp({
+  email: 'test@lolly.tn',
+  password: 'test1234',
+  firstName: 'Marie',
+  lastName: 'Dupont',
+  role: 'client',
+});
+```
+
+## Connexion
+```ts
+const { error } = await signIn(email, password);
+```
+
+## Connexion Facebook
+```ts
+await signInWithFacebook();
+```
+Les identifiants `facebook_id` et `messenger_id` sont automatiquement enregistrés lors du premier retour de session.
+
+## Redirections selon le rôle
+- `client` → `/client/dashboard`
+- `advisor` → `/conseillere/dashboard`
+- `admin` → `/admin/dashboard`
+
+Toute route protégée utilise `ProtectedRoute`:
+```tsx
+<Route path="/admin/dashboard" element={
+  <ProtectedRoute roles={["admin"]}>
+    <AdminDashboard />
+  </ProtectedRoute>
+} />
+```
+
+Aucune conseillère ne peut accéder au tableau de bord client (et donc au parrainage) grâce à cette vérification de rôle.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,16 +1,49 @@
-import { Routes, Route, Navigate } from 'react-router-dom'
-import Catalogue from './pages/Catalogue'
+import { Routes, Route, Navigate } from 'react-router-dom';
+import Catalogue from './pages/Catalogue';
+import Home from '@/components/home';
+import LoginPage from '@/components/LoginPage';
+import CreateAccountPage from '@/components/CreateAccountPage';
+import ClientDashboard from '@/components/ClientDashboard';
+import ConseillereDashboard from '@/components/ConseillereDashboard';
+import AdminDashboard from '@/components/AdminDashboard';
+import ProtectedRoute from '@/components/ProtectedRoute';
 
 function App() {
   return (
     <Routes>
-      {/* Redirection automatique de la racine vers /catalogue */}
-      <Route path="/" element={<Navigate to="/catalogue" />} />
-
-      {/* Route du catalogue */}
+      <Route path="/" element={<Home />} />
       <Route path="/catalogue" element={<Catalogue />} />
+      <Route path="/client/login" element={<LoginPage userType="client" />} />
+      <Route path="/conseillere/login" element={<LoginPage userType="conseillere" />} />
+      <Route path="/admin/login" element={<LoginPage userType="admin" />} />
+      <Route path="/client/create-account" element={<CreateAccountPage />} />
+      <Route
+        path="/client/dashboard"
+        element={
+          <ProtectedRoute roles={['client']}>
+            <ClientDashboard />
+          </ProtectedRoute>
+        }
+      />
+      <Route
+        path="/conseillere/dashboard"
+        element={
+          <ProtectedRoute roles={['advisor']}>
+            <ConseillereDashboard />
+          </ProtectedRoute>
+        }
+      />
+      <Route
+        path="/admin/dashboard"
+        element={
+          <ProtectedRoute roles={['admin']}>
+            <AdminDashboard />
+          </ProtectedRoute>
+        }
+      />
+      <Route path="*" element={<Navigate to="/" replace />} />
     </Routes>
-  )
+  );
 }
 
-export default App
+export default App;

--- a/src/components/AdminDashboard.tsx
+++ b/src/components/AdminDashboard.tsx
@@ -1,5 +1,6 @@
 import { useNavigate } from "react-router-dom";
 import { Button } from "@/components/ui/button";
+import { useAuth } from "@/hooks/useAuth";
 import {
   ArrowLeft,
   Package,
@@ -23,8 +24,10 @@ import {
 
 function AdminDashboard() {
   const navigate = useNavigate();
+  const { signOut } = useAuth();
 
-  const handleLogout = () => {
+  const handleLogout = async () => {
+    await signOut();
     navigate("/");
   };
 

--- a/src/components/ClientDashboard.tsx
+++ b/src/components/ClientDashboard.tsx
@@ -53,6 +53,7 @@ import {
   Copy,
   Check,
 } from "lucide-react";
+import { useAuth } from "@/hooks/useAuth";
 
 // Types pour la simulation
 type ViewType =
@@ -96,6 +97,7 @@ interface CartItem {
 
 function ClientDashboard() {
   const navigate = useNavigate();
+  const { signOut } = useAuth();
   const [currentView, setCurrentView] = useState<ViewType>("catalog");
   const [selectedProduct, setSelectedProduct] = useState<Product | null>(null);
   const [selectedSize, setSelectedSize] = useState<string>("30ml");
@@ -335,6 +337,11 @@ function ClientDashboard() {
     return { subtotal, tax, total: subtotal + tax };
   };
 
+  const handleLogout = async () => {
+    await signOut();
+    navigate("/");
+  };
+
   const renderCatalog = () => (
     <div className="min-h-screen bg-lolly-background font-montserrat">
       {/* Header */}
@@ -529,19 +536,28 @@ function ClientDashboard() {
           <h1 className="text-xl font-playfair font-bold text-lolly-contrast">
             Mon Espace Client
           </h1>
-          <Button
-            variant="ghost"
-            className="text-lolly-contrast hover:bg-lolly-primary/10 relative text-sm px-2"
-            onClick={() => setCurrentView("cart")}
-          >
-            <ShoppingCart className="w-4 h-4 mr-1" />
-            <span className="hidden sm:inline">Panier</span>
-            {cartItems.length > 0 && (
-              <Badge className="absolute -top-2 -right-2 bg-lolly-primary text-white text-xs">
-                {cartItems.length}
-              </Badge>
-            )}
-          </Button>
+          <div className="flex items-center space-x-2">
+            <Button
+              variant="ghost"
+              className="text-lolly-contrast hover:bg-lolly-primary/10 relative text-sm px-2"
+              onClick={() => setCurrentView("cart")}
+            >
+              <ShoppingCart className="w-4 h-4 mr-1" />
+              <span className="hidden sm:inline">Panier</span>
+              {cartItems.length > 0 && (
+                <Badge className="absolute -top-2 -right-2 bg-lolly-primary text-white text-xs">
+                  {cartItems.length}
+                </Badge>
+              )}
+            </Button>
+            <Button
+              variant="ghost"
+              onClick={handleLogout}
+              className="text-lolly-contrast hover:bg-red-50 hover:text-red-600 text-sm px-2"
+            >
+              Déconnexion
+            </Button>
+          </div>
         </div>
       </header>
 

--- a/src/components/ConseillereDashboard.tsx
+++ b/src/components/ConseillereDashboard.tsx
@@ -44,9 +44,11 @@ import {
   Trash2,
   RotateCcw,
 } from "lucide-react";
+import { useAuth } from "@/hooks/useAuth";
 
 function ConseillereDashboard() {
   const navigate = useNavigate();
+  const { signOut } = useAuth();
   const [currentView, setCurrentView] = useState<
     "dashboard" | "catalog" | "favorites"
   >("dashboard");
@@ -58,6 +60,11 @@ function ConseillereDashboard() {
   const [clientSearchTerm, setClientSearchTerm] = useState("");
   const [selectedDateRange, setSelectedDateRange] = useState("today");
 
+  const handleLogout = async () => {
+    await signOut();
+    navigate("/");
+  };
+
   // Force component to render with explicit styles
   console.log("ConseillereDashboard LOADED - currentView:", currentView);
 
@@ -65,10 +72,6 @@ function ConseillereDashboard() {
   React.useEffect(() => {
     console.log("ConseillereDashboard mounted successfully");
   }, []);
-
-  const handleLogout = () => {
-    navigate("/");
-  };
 
   const toggleFavorite = (productId: string) => {
     setFavorites((prev) =>
@@ -93,40 +96,7 @@ function ConseillereDashboard() {
     clearFavorites(); // Clear favorites after sale
   };
 
-  const filteredProducts = perfumes.filter((product) => {
-    const matchesSearch =
-      searchTerm === "" ||
-      product.lollyName.toLowerCase().includes(searchTerm.toLowerCase()) ||
-      product.inspiredPerfume
-        .toLowerCase()
-        .includes(searchTerm.toLowerCase()) ||
-      product.brand.toLowerCase().includes(searchTerm.toLowerCase());
-
-    const matchesIngredient =
-      ingredientSearch === "" ||
-      product.notes.top
-        .toLowerCase()
-        .includes(ingredientSearch.toLowerCase()) ||
-      product.notes.heart
-        .toLowerCase()
-        .includes(ingredientSearch.toLowerCase()) ||
-      product.notes.base
-        .toLowerCase()
-        .includes(ingredientSearch.toLowerCase()) ||
-      product.family.toLowerCase().includes(ingredientSearch.toLowerCase());
-
-    return matchesSearch && matchesIngredient;
-  });
-
-  const filteredClients = clients.filter((client) => {
-    if (clientSearchTerm === "") return true;
-    const searchLower = clientSearchTerm.toLowerCase();
-    return (
-      client.name.toLowerCase().includes(searchLower) ||
-      client.phone.includes(clientSearchTerm) ||
-      client.email.toLowerCase().includes(searchLower)
-    );
-  });
+  // filteredProducts & filteredClients defined after data arrays
 
   const getSalesHistory = () => {
     // Sample sales history based on selected date range
@@ -352,6 +322,41 @@ function ConseillereDashboard() {
       ],
     },
   ];
+
+  const filteredProducts = perfumes.filter((product) => {
+    const matchesSearch =
+      searchTerm === "" ||
+      product.lollyName.toLowerCase().includes(searchTerm.toLowerCase()) ||
+      product.inspiredPerfume
+        .toLowerCase()
+        .includes(searchTerm.toLowerCase()) ||
+      product.brand.toLowerCase().includes(searchTerm.toLowerCase());
+
+    const matchesIngredient =
+      ingredientSearch === "" ||
+      product.notes.top
+        .toLowerCase()
+        .includes(ingredientSearch.toLowerCase()) ||
+      product.notes.heart
+        .toLowerCase()
+        .includes(ingredientSearch.toLowerCase()) ||
+      product.notes.base
+        .toLowerCase()
+        .includes(ingredientSearch.toLowerCase()) ||
+      product.family.toLowerCase().includes(ingredientSearch.toLowerCase());
+
+    return matchesSearch && matchesIngredient;
+  });
+
+  const filteredClients = clients.filter((client) => {
+    if (clientSearchTerm === "") return true;
+    const searchLower = clientSearchTerm.toLowerCase();
+    return (
+      client.name.toLowerCase().includes(searchLower) ||
+      client.phone.includes(clientSearchTerm) ||
+      client.email.toLowerCase().includes(searchLower)
+    );
+  });
 
   // Promotions actives
   const promotions = [

--- a/src/components/CreateAccountPage.tsx
+++ b/src/components/CreateAccountPage.tsx
@@ -1,13 +1,14 @@
-import { useState } from "react";
-import { supabase } from "@/lib/supabase";
+import { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { ArrowLeft, Eye, EyeOff } from "lucide-react";
+import { useAuth } from "@/hooks/useAuth";
 
 function CreateAccountPage() {
   const navigate = useNavigate();
+  const { signUp, profile } = useAuth();
 
   const [formData, setFormData] = useState({
     firstName: "",
@@ -47,25 +48,26 @@ function CreateAccountPage() {
       return;
     }
 
-    const { error: signUpError } = await supabase.auth.signUp({
+    const { error: signUpError } = await signUp({
       email: formData.email,
       password: formData.password,
-      options: {
-        data: {
-          first_name: formData.firstName,
-          last_name: formData.lastName,
-        },
-      },
+      firstName: formData.firstName,
+      lastName: formData.lastName,
+      role: "client",
     });
 
     if (signUpError) {
-      setError(signUpError.message);
-    } else {
-      navigate("/client/dashboard");
+      setError(signUpError);
     }
 
     setIsLoading(false);
   };
+
+  useEffect(() => {
+    if (profile?.role === "client") {
+      navigate("/client/dashboard");
+    }
+  }, [profile, navigate]);
 
   return (
     <div className="min-h-screen bg-lolly-background font-montserrat">
@@ -74,7 +76,7 @@ function CreateAccountPage() {
         <div className="max-w-4xl mx-auto px-4 py-4 flex items-center">
           <Button
             variant="ghost"
-            onClick={() => navigate("/client")}
+            onClick={() => navigate("/client/login")}
             className="mr-4 text-lolly-contrast hover:bg-lolly-primary/10"
           >
             <ArrowLeft className="w-4 h-4 mr-2" />

--- a/src/components/ProtectedRoute.tsx
+++ b/src/components/ProtectedRoute.tsx
@@ -1,0 +1,32 @@
+import { Navigate, Outlet } from 'react-router-dom';
+import { ReactNode } from 'react';
+import { useAuth } from '@/hooks/useAuth';
+import type { Role } from '@/context/AuthProvider';
+
+interface ProtectedRouteProps {
+  roles?: Role[];
+  children?: ReactNode;
+}
+
+const roleToPath: Record<Role, string> = {
+  client: '/client/dashboard',
+  advisor: '/conseillere/dashboard',
+  admin: '/admin/dashboard',
+};
+
+export function ProtectedRoute({ roles, children }: ProtectedRouteProps) {
+  const { user, profile, loading } = useAuth();
+
+  if (loading) return null;
+  if (!user) {
+    return <Navigate to="/client/login" replace />;
+  }
+
+  if (roles && profile && !roles.includes(profile.role)) {
+    return <Navigate to={roleToPath[profile.role]} replace />;
+  }
+
+  return children ? <>{children}</> : <Outlet />;
+}
+
+export default ProtectedRoute;

--- a/src/components/home.tsx
+++ b/src/components/home.tsx
@@ -1,9 +1,26 @@
 import { useNavigate } from "react-router-dom";
 import { Button } from "@/components/ui/button";
 import { User, Flower, Settings } from "lucide-react";
+import { useAuth } from "@/hooks/useAuth";
 
 function Home() {
   const navigate = useNavigate();
+  const { profile } = useAuth();
+
+  const goClient = () => {
+    if (profile?.role === "client") navigate("/client/dashboard");
+    else navigate("/client/login");
+  };
+
+  const goAdvisor = () => {
+    if (profile?.role === "advisor") navigate("/conseillere/dashboard");
+    else navigate("/conseillere/login");
+  };
+
+  const goAdmin = () => {
+    if (profile?.role === "admin") navigate("/admin/dashboard");
+    else navigate("/admin/login");
+  };
 
   return (
     <div className="min-h-screen bg-lolly-background font-montserrat">
@@ -47,7 +64,7 @@ function Home() {
             </h3>
 
             <Button
-              onClick={() => navigate("/client")}
+              onClick={goClient}
               className="w-full bg-lolly-primary hover:bg-lolly-primary/90 text-white font-medium py-3"
             >
               Accéder
@@ -64,7 +81,7 @@ function Home() {
             </h3>
 
             <Button
-              onClick={() => navigate("/conseillere/login")}
+              onClick={goAdvisor}
               className="w-full bg-lolly-gold hover:bg-lolly-gold/90 text-lolly-contrast font-medium py-3"
             >
               Se connecter
@@ -81,7 +98,7 @@ function Home() {
             </h3>
 
             <Button
-              onClick={() => navigate("/admin/login")}
+              onClick={goAdmin}
               className="w-full bg-lolly-contrast hover:bg-lolly-contrast/90 text-white font-medium py-3"
             >
               Se connecter

--- a/src/context/AuthProvider.tsx
+++ b/src/context/AuthProvider.tsx
@@ -1,0 +1,186 @@
+import { createContext, useContext, useEffect, useState, ReactNode } from 'react';
+import { supabase } from '@/lib/supabase';
+import type { User } from '@supabase/supabase-js';
+
+export type Role = 'client' | 'advisor' | 'admin';
+
+interface UserProfile {
+  id: string;
+  first_name?: string;
+  last_name?: string;
+  email?: string;
+  role: Role;
+  facebook_id?: string | null;
+  messenger_id?: string | null;
+}
+
+interface AuthContextValue {
+  user: User | null;
+  profile: UserProfile | null;
+  loading: boolean;
+  signIn: (email: string, password: string) => Promise<{ error?: string }>;
+  signUp: (params: {
+    email: string;
+    password: string;
+    firstName: string;
+    lastName: string;
+    role?: Role;
+  }) => Promise<{ error?: string }>;
+  signOut: () => Promise<void>;
+  signInWithFacebook: () => Promise<void>;
+}
+
+export const AuthContext = createContext<AuthContextValue | undefined>(
+  undefined,
+);
+
+export const AuthProvider = ({ children }: { children: ReactNode }) => {
+  const [user, setUser] = useState<User | null>(null);
+  const [profile, setProfile] = useState<UserProfile | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  const fetchProfile = async (userId: string) => {
+    const { data } = await supabase
+      .from('users')
+      .select('*')
+      .eq('id', userId)
+      .single();
+    return data as UserProfile | null;
+  };
+
+  useEffect(() => {
+    const setup = async () => {
+      const {
+        data: { session },
+      } = await supabase.auth.getSession();
+      const currentUser = session?.user ?? null;
+      setUser(currentUser);
+      if (currentUser) {
+        let profileData = await fetchProfile(currentUser.id);
+        if (!profileData) {
+          const facebookIdentity = currentUser.identities?.find(
+            (i) => i.provider === 'facebook',
+          );
+          const facebookId =
+            (facebookIdentity?.identity_data as any)?.id ||
+            (facebookIdentity?.identity_data as any)?.sub ||
+            null;
+          const messengerId =
+            (currentUser.user_metadata as any)?.messenger_id || null;
+          const role =
+            ((currentUser.user_metadata as any)?.role as Role) || 'client';
+          const { data } = await supabase
+            .from('users')
+            .insert({
+              id: currentUser.id,
+              email: currentUser.email,
+              first_name: (currentUser.user_metadata as any)?.first_name,
+              last_name: (currentUser.user_metadata as any)?.last_name,
+              facebook_id: facebookId,
+              messenger_id: messengerId,
+              role,
+            })
+            .select()
+            .single();
+          profileData = data as UserProfile;
+        }
+        setProfile(profileData);
+      }
+      setLoading(false);
+    };
+    setup();
+    const {
+      data: { subscription },
+    } = supabase.auth.onAuthStateChange(async (_event, session) => {
+      const currentUser = session?.user ?? null;
+      setUser(currentUser);
+      if (currentUser) {
+        const profileData = await fetchProfile(currentUser.id);
+        setProfile(profileData);
+      } else {
+        setProfile(null);
+      }
+    });
+    return () => subscription.unsubscribe();
+  }, []);
+
+  const signIn = async (email: string, password: string) => {
+    const { error } = await supabase.auth.signInWithPassword({ email, password });
+    if (error) {
+      return { error: error.message };
+    }
+    const {
+      data: { user: currentUser },
+    } = await supabase.auth.getUser();
+    if (currentUser) {
+      const profileData = await fetchProfile(currentUser.id);
+      setProfile(profileData);
+    }
+    return {};
+  };
+
+  const signUp = async ({
+    email,
+    password,
+    firstName,
+    lastName,
+    role = 'client',
+  }: {
+    email: string;
+    password: string;
+    firstName: string;
+    lastName: string;
+    role?: Role;
+  }) => {
+    const { data, error } = await supabase.auth.signUp({
+      email,
+      password,
+      options: { data: { first_name: firstName, last_name: lastName, role } },
+    });
+    if (error || !data.user) {
+      return { error: error?.message || 'Unable to sign up' };
+    }
+    await supabase.from('users').insert({
+      id: data.user.id,
+      email,
+      first_name: firstName,
+      last_name: lastName,
+      role,
+    });
+    setUser(data.user);
+    setProfile({
+      id: data.user.id,
+      email,
+      first_name: firstName,
+      last_name: lastName,
+      role,
+    });
+    return {};
+  };
+
+  const signOut = async () => {
+    await supabase.auth.signOut();
+    setUser(null);
+    setProfile(null);
+  };
+
+  const signInWithFacebook = async () => {
+    await supabase.auth.signInWithOAuth({ provider: 'facebook' });
+  };
+
+  return (
+    <AuthContext.Provider
+      value={{ user, profile, loading, signIn, signUp, signOut, signInWithFacebook }}
+    >
+      {children}
+    </AuthContext.Provider>
+  );
+};
+
+export const useAuthContext = () => {
+  const context = useContext(AuthContext);
+  if (!context) throw new Error('useAuthContext must be used within AuthProvider');
+  return context;
+};
+
+export default AuthProvider;

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -1,0 +1,12 @@
+import { useContext } from 'react';
+import { AuthContext } from '@/context/AuthProvider';
+
+export const useAuth = () => {
+  const ctx = useContext(AuthContext);
+  if (!ctx) {
+    throw new Error('useAuth must be used within an AuthProvider');
+  }
+  return ctx;
+};
+
+export default useAuth;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,6 +3,7 @@ import ReactDOM from "react-dom/client";
 import App from "./App.tsx";
 import "./index.css";
 import { BrowserRouter } from "react-router-dom";
+import { AuthProvider } from "@/context/AuthProvider";
 
 import { TempoDevtools } from "tempo-devtools";
 TempoDevtools.init();
@@ -12,7 +13,9 @@ const basename = import.meta.env.BASE_URL;
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
     <BrowserRouter basename={basename}>
-      <App />
+      <AuthProvider>
+        <App />
+      </AuthProvider>
     </BrowserRouter>
   </React.StrictMode>,
 );


### PR DESCRIPTION
## Summary
- add AuthProvider with Supabase session, role storage and Facebook OAuth hooks
- protect routes and redirect users to dashboards based on role
- document authentication flow

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688d9eaf92c4832ba8b98936b47397ef