### PR TITLE
Handle login errors and reset loading

### DIFF
--- a/src/pages/ClientLogin.tsx
+++ b/src/pages/ClientLogin.tsx
@@ -14,17 +14,21 @@ export default function ClientLogin() {
   const handleLogin = async () => {
     setLoading(true);
     setErrorMsg("");
+    try {
+      const { error } = await supabase.auth.signInWithPassword({
+        email,
+        password,
+      });
 
-    const { error } = await supabase.auth.signInWithPassword({
-      email,
-      password,
-    });
-
-    if (error) {
-      setErrorMsg("Email ou mot de passe incorrect");
+      if (error) {
+        setErrorMsg("Email ou mot de passe incorrect");
+      } else {
+        navigate("/client/catalogue");
+      }
+    } catch (error) {
+      setErrorMsg("Erreur lors de la connexion");
+    } finally {
       setLoading(false);
-    } else {
-      navigate("/client/catalogue");
     }
   };
 


### PR DESCRIPTION
## Summary
- wrap `signInWithPassword` in `try/catch/finally`
- show appropriate error message and always reset `loading`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688fab8b715c832b85df84009ddd7def