### PR TITLE
feat: add auth user seed script

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,12 @@ Développer une application web responsive pour la marque Lolly, intégrant :
 - Exécuter le fichier `schema_Lolly_2025-07-31_version4.sql`
 - Puis exécuter le fichier `seed_Lolly_2025-07-31_version6.sql`
 
-### 3. Vérifications à faire :
+### 3. Ajouter l'utilisateur d'authentification
+- Après l'import du fichier `seed.sql`, exécuter `npx ts-node scripts/seedAuthUsers.ts`
+  (nécessite la variable d'environnement `SUPABASE_SERVICE_ROLE_KEY`).
+- L'utilisateur `client@lolly.tn` sera créé dans `auth.users` et répliqué dans la table `users`.
+
+### 4. Vérifications à faire :
 - 6 niveaux Lolly
 - 6 utilisateurs (3 clients, 2 conseillères, 1 admin)
 - 6 parfums + variantes
@@ -42,7 +47,7 @@ Développer une application web responsive pour la marque Lolly, intégrant :
 - 3 commissions multi-niveaux
 - 1 notification de bienvenue
 
-### 4. Frontend
+### 5. Frontend
 - Construire une application React (mobile-first)
 - Respecter la charte graphique :
   - Couleurs : #CE8F8A, #FBF0E9, #805050, #D4C2A1, #AD9C92

--- a/scripts/seedAuthUsers.ts
+++ b/scripts/seedAuthUsers.ts
@@ -1,0 +1,39 @@
+import { createClient } from '@supabase/supabase-js';
+
+const SUPABASE_URL = process.env.SUPABASE_URL || process.env.VITE_SUPABASE_URL;
+const SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+if (!SUPABASE_URL || !SERVICE_ROLE_KEY) {
+  console.error('Missing SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY environment variables');
+  process.exit(1);
+}
+
+const supabase = createClient(SUPABASE_URL, SERVICE_ROLE_KEY, {
+  auth: {
+    autoRefreshToken: false,
+    persistSession: false,
+  },
+});
+
+async function main() {
+  const { data, error } = await supabase.auth.admin.createUser({
+    id: '9972d0f5-68f7-4222-bccf-78ef5ef3ea84',
+    email: 'client@lolly.tn',
+    password: 'taftoufa',
+    email_confirm: true,
+    user_metadata: {
+      first_name: 'Leila',
+      last_name: 'Lclient',
+      role: 'client',
+    },
+  });
+
+  if (error) {
+    console.error('Error creating auth user:', error);
+    process.exit(1);
+  }
+
+  console.log('Created auth user:', data.user?.id);
+}
+
+main();


### PR DESCRIPTION
## Summary
- add seedAuthUsers script to create `client@lolly.tn` via Supabase admin API
- document running auth seeding after SQL seed import

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: ESLint couldn't find a configuration file)


------
https://chatgpt.com/codex/tasks/task_e_688fd18876a0832bab8319750f8e8cba