### PR TITLE
chore: require Supabase env variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,14 @@ Développer une application web responsive pour la marque Lolly, intégrant :
   (nécessite la variable d'environnement `SUPABASE_SERVICE_ROLE_KEY`).
 - L'utilisateur `client@lolly.tn` sera créé dans `auth.users` et répliqué dans la table `users`.
 
+### Variables d'environnement requises
+Dans votre fichier `.env`, définissez :
+
+```
+VITE_SUPABASE_URL=<URL de votre projet Supabase>
+VITE_SUPABASE_ANON_KEY=<clé publique Supabase>
+```
+
 ### Identifiants de démonstration (optionnel)
 Vous pouvez pré-remplir le formulaire de connexion avec un compte de test en définissant dans votre fichier `.env` :
 

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,11 +1,8 @@
 import { createClient } from '@supabase/supabase-js';
 import type { Database } from '@/types/supabase';
 
-const SUPABASE_URL =
-  import.meta.env.VITE_SUPABASE_URL || 'https://lftouuybkowdqimpgrnr.supabase.co';
-const SUPABASE_ANON_KEY =
-  import.meta.env.VITE_SUPABASE_ANON_KEY ||
-  'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImxmdG91dXlia293ZHFpbXBncm5yIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTQwOTYzMzMsImV4cCI6MjA2OTY3MjMzM30.TFTdCZA9Ej8wpCTx5q0QS88qLAk_aKavdAiVLiwkPFM';
+const SUPABASE_URL = import.meta.env.VITE_SUPABASE_URL;
+const SUPABASE_ANON_KEY = import.meta.env.VITE_SUPABASE_ANON_KEY;
 
 export const supabase = createClient<Database>(SUPABASE_URL, SUPABASE_ANON_KEY);
 


### PR DESCRIPTION
## Summary
- remove default Supabase credentials to rely on environment variables
- document required Supabase env vars in README

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_688fe2e502cc832ba2f98d20e00322f1